### PR TITLE
[refactor] Import external links in css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2,3 +2,7 @@
 @import url("./stylesheets/reset.css");
 @import url("./stylesheets/utilities.css");
 @import url("./components/component.css");
+
+@import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800;900&display=swap");
+
+@import url("https://use.fontawesome.com/releases/v5.15.4/css/all.css");


### PR DESCRIPTION
Imported links for Google Fonts and Font Awesome Icons directly into `styles.css`, 
so that users of the library need not have to import them again in their projects